### PR TITLE
Change matrix top labels

### DIFF
--- a/src/encoded/types/experiment.py
+++ b/src/encoded/types/experiment.py
@@ -562,7 +562,7 @@ class Experiment(Dataset,
                 'month_released',
                 'files.file_type',
             ],
-            'group_by': 'assay_title',
+            'group_by': 'target.label',
             'label': 'Assay',
         },
     }


### PR DESCRIPTION
Changed the top labels from assay_title to target.label. Cricket also suggested sorting these by target.investigated_as, but we need a demo deployed ASAP for a call. No Redmine